### PR TITLE
Replace pulp.h include with pmsis.h

### DIFF
--- a/32bit/include/pulp_nn_utils.h
+++ b/32bit/include/pulp_nn_utils.h
@@ -18,9 +18,7 @@
  * limitations under the License.
  */
 
-#ifdef GAP_SDK
-#include "pulp.h"
-#endif
+#include "pmsis.h"
 
 uint8_t pulp_nn_bn_quant_u8 (int32_t phi, int32_t k, int32_t lambda, int8_t  d);
 

--- a/64bit/include/pulp_nn_utils.h
+++ b/64bit/include/pulp_nn_utils.h
@@ -18,9 +18,7 @@
  * limitations under the License.
  */
 
-#ifdef GAP_SDK
-#include "pulp.h"
-#endif
+#include "pmsis.h"
 
 uint8_t pulp_nn_bn_quant_u8 (int32_t phi, int64_t k, int64_t lambda, int8_t  d);
 


### PR DESCRIPTION
It makes no sense to include `pulp.h` in GAP_SDK. Fails compilation for GAP9.